### PR TITLE
Handle context cancellation to shutdown the exporter

### DIFF
--- a/cmd/prometheus-plex-exporter/main.go
+++ b/cmd/prometheus-plex-exporter/main.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -12,33 +17,69 @@ import (
 	"github.com/grafana/plexporter/pkg/plex"
 )
 
+const (
+	MetricsServerAddr = ":9000"
+)
+
 var (
 	log = kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
 )
 
 func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
 
 	serverAddress := os.Getenv("PLEX_SERVER")
 	if serverAddress == "" {
 		level.Error(log).Log("msg", "PLEX_SERVER environment variable must be specified")
-		return
+		os.Exit(1)
 	}
 
 	plexToken := os.Getenv("PLEX_TOKEN")
 	if plexToken == "" {
 		level.Error(log).Log("msg", "PLEX_TOKEN environment variable must be specified")
-		return
+		os.Exit(1)
 	}
 
 	server, err := plex.NewServer(serverAddress, plexToken)
 	if err != nil {
-		level.Error(log).Log("msg", err)
-		return
+		level.Error(log).Log("msg", "cannot initialize connection to plex server", "error", err)
+		os.Exit(1)
 	}
-	server.Listen(log)
 
 	metrics.Register(server)
 
-	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(":9000", nil)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	metricsServer := http.Server{
+		Addr:         MetricsServerAddr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	go func() {
+		level.Info(log).Log("msg", "starting metrics server on "+MetricsServerAddr)
+		err = metricsServer.ListenAndServe()
+		if !errors.Is(err, http.ErrServerClosed) {
+			level.Error(log).Log("msg", "cannot start metrics server", "error", err)
+		}
+	}()
+
+	exitCode := 0
+	err = server.Listen(ctx, log)
+	if err != nil {
+		level.Error(log).Log("msg", "cannot listen to plex server events", "error", err)
+		exitCode = 1
+	}
+
+	level.Debug(log).Log("msg", "shutting down metrics server")
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer shutdownCancel()
+	if err := metricsServer.Shutdown(shutdownCtx); err != nil {
+		level.Error(log).Log("msg", "cannot gracefully shutdown metrics server", "error", err)
+	}
+
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
Hello !
I've added context to handle the ctrl+c interrupt across the app

This gracefully close the metrics http server and the plex event websocket.

This is also a workaround for #6 and #16 as it terminate the program if there is a error on the websocket connection
